### PR TITLE
Fix regex in extract_usb_address

### DIFF
--- a/src/application/cc_base.cpp
+++ b/src/application/cc_base.cpp
@@ -17,13 +17,13 @@
 static bool extract_usb_address(const String &str, uint_t &bus, uint_t &device)
 {
 	boost::cmatch what;
-	boost::regex regex("([\\d]{1,3}):([\\d]{1,3})");
+	boost::regex regex("([\\da-fA-F]{1,4}):([\\da-fA-F]{1,4})");
 
 	if (!boost::regex_match(str.c_str(), what, regex))
 		return false;
 
-	string_to_number(what[1].str(), bus);
-	string_to_number(what[2].str(), device);
+	hexstring_to_number(what[1].str(), bus);
+	hexstring_to_number(what[2].str(), device);
 	return true;
 }
 

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -80,4 +80,14 @@ inline bool string_to_number(const String &string, T &number)
 	return string.empty() || *bad_character == '\0';
 }
 
+//==============================================================================
+template<typename T>
+inline bool hexstring_to_number(const String &string, T &number)
+{
+	char *bad_character = NULL;
+	number = strtoul(string.c_str(), &bad_character, 16);
+
+	return string.empty() || *bad_character == '\0';
+}
+
 #endif // !_COMMON_H_


### PR DESCRIPTION
extract_usb_address matched the string to a pair of decimal numbers with 1 to 3 digits, `"([\\d]{1,3}):([\\d]{1,3})`. The correct format of VID and PID is a hexadecimal number with up to 4 digits, `"([\\da-fA-F]{1,4}):([\\da-fA-F]{1,4})"`. The `string_to_number` call was also replaced with a `hexstring_to_number` call.