### PR TITLE
Add missing <stdarg.h> include for va_list

### DIFF
--- a/src/common/log.h
+++ b/src/common/log.h
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include "common.h"
 
 class Log


### PR DESCRIPTION
Fixes the build on uClibc.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>