### PR TITLE
Fixed libusb_set_debug deprecation warning for libusb>=1.0.22

### DIFF
--- a/src/usb/usb_device.cpp
+++ b/src/usb/usb_device.cpp
@@ -255,7 +255,11 @@ void USB_Device::set_transfer_timeout(uint_t timeout)
 //==============================================================================
 void USB_Device::set_debug_mode(DebugLevel level)
 {
+#if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000106)
+	libusb_set_option(context_.get(), LIBUSB_OPTION_LOG_LEVEL, level);
+#else
 	libusb_set_debug(context_.get(), level);
+#endif
 }
 
 //==============================================================================


### PR DESCRIPTION
This fixes the libusb_set_debug deprecation warning when using libusb 1.0.22 or higher.